### PR TITLE
feat: g6 render support resize to fit viewport & support edge mark

### DIFF
--- a/src/adaptor/g6/render.ts
+++ b/src/adaptor/g6/render.ts
@@ -1,13 +1,30 @@
 import G6 from '@antv/g6';
 
 export function g6Render(g6Cfg: any, container: HTMLElement) {
-  if (g6Cfg?.data && g6Cfg?.cfg) {
+  if (g6Cfg?.data && g6Cfg?.cfg && container) {
     const graph = new G6.Graph({
       container,
       ...g6Cfg.cfg,
     });
     graph.data(g6Cfg.data);
     graph.render();
+
+    // auto resize the graph to fit the container viewport
+    const resizeGraphToFit = () => {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      if (width && height) {
+        const maxX = Math.max(...graph.getNodes().map((node) => node.getModel().x));
+        const maxY = Math.max(...graph.getNodes().map((node) => node.getModel().y));
+        const { x: clientMaxX, y: clientMaxY } = graph.getClientByPoint(maxX, maxY);
+        graph.zoomTo(Math.min(width / clientMaxX, height / clientMaxY));
+        graph.changeSize(width, height);
+      }
+    };
+    resizeGraphToFit();
+    window.onresize = () => {
+      resizeGraphToFit();
+    };
     return graph;
   }
 

--- a/src/adaptor/g6/toConfig.ts
+++ b/src/adaptor/g6/toConfig.ts
@@ -104,6 +104,12 @@ export function specToG6Config(spec: GraphAntVSpec) {
   const { edges } = g6Data;
   const edgesEnc = 'links' in spec.layer[0] ? spec.layer[0].links : null;
   if (edgesEnc) {
+    if (edgesEnc.mark) {
+      edges.forEach((edge: any) => {
+        const updateEdge = edge;
+        updateEdge.type = edgesEnc.mark;
+      });
+    }
     if (edgesEnc.encoding?.color) {
       // have color encoding for edges
       const { field, scale } = edgesEnc.encoding.color;


### PR DESCRIPTION
- resize graph to fit its container viewport
- support edge mark specification in g6 adapter